### PR TITLE
Slow plugin cheat

### DIFF
--- a/FunctionNameStatus.py
+++ b/FunctionNameStatus.py
@@ -23,7 +23,7 @@ class FunctionNameStatusEventHandler(sublime_plugin.EventListener):
     now = time.time()
     if now - Pref.time > Pref.wait_time:
       Pref.time = now
-      self.display_current_class_and_function(view)
+      sublime.set_timeout(lambda:self.display_current_class_and_function(view), 0)
     else:
       Pref.time = now
 


### PR DESCRIPTION
View.find_by_selector is an slow API call. Since we can't do nothing (without so much hacking, read as: writting our own parser ) to improve the situation we must cheat to remove the "slow plugin" message

Buah, many commits for so tiny change.
