### PR TITLE
BugFix with C files

### DIFF
--- a/FunctionNameStatus.py
+++ b/FunctionNameStatus.py
@@ -1,4 +1,3 @@
-
 import sublime, sublime_plugin, thread, re
 from time import time, sleep
 
@@ -93,7 +92,7 @@ class FunctionNameStatusEventHandler(sublime_plugin.EventListener):
                 s += name.strip()
               else:
                 if 'C++' in view.settings().get('syntax'):
-                  if Pref.display_class:
+                  if Pref.display_class or len(name.split('(')[0].split('::'))<2:
                     s += name.split('(')[0].strip()
                   else:
                     s += name.split('(')[0].split('::')[1].strip()


### PR DESCRIPTION
Hi,

I made a small update to your plugin to avoid error with C files when the display_class is false: the function now check for the operator :: before trying to take the second part of the split.

Thanks for your plugin, it's really cool :)
