### PR TITLE
ST3 support

### DIFF
--- a/FunctionNameStatus.py
+++ b/FunctionNameStatus.py
@@ -41,13 +41,13 @@ class FunctionNameStatusEventHandler(sublime_plugin.EventListener):
     def on_modified(self, view):
         Pref.time = time()
 
-    # hopefully async is a good choice
-    def on_selection_modified_async(self, view):
+    # could be async, but ST2 does not support that
+    def on_selection_modified(self, view):
         now = time()
         if now - Pref.time > Pref.wait_time:
             sublime.set_timeout(lambda:self.display_current_class_and_function(view, 'selection_modified'), 0)
         else:
-            sublime.set_timeout(lambda:self.display_current_class_and_function_delayed(view), 1000*Pref.wait_time)
+            sublime.set_timeout(lambda:self.display_current_class_and_function_delayed(view), int(1000*Pref.wait_time))
         Pref.time = now
 
     def display_current_class_and_function_delayed(self, view):


### PR DESCRIPTION
In case you are interested, I've updated FunctionNameDisplay to work with SublimeText 3 beta. There are a several of differences:
- settings should be loaded later in loading process, rather than instantly: from within `plugin_loaded` method, or on demand (I chose the former).
- `thread` is not present in python3, so I reimplemented the watchdog part using second `set_timeout` call.

The diff is all messed up for some reason, and there are some debatable implementation changes within, so it is no big deal if you choose to discard the pull request. If you find some issues with the changes, though, it would be cool to hear back.
