### PR TITLE
Filter out inline functions

### DIFF
--- a/FunctionNameStatus.py
+++ b/FunctionNameStatus.py
@@ -89,7 +89,7 @@ class FunctionNameStatusEventHandler(sublime_plugin.EventListener):
 
             # Look for any functions
             if Pref.display_function:
-                function_regions = view.find_by_selector('meta.function')
+                function_regions = view.find_by_selector('meta.function - meta.function.inline')
                 if function_regions:
                     for r in reversed(function_regions):
                         row, col = view.rowcol(r.begin())


### PR DESCRIPTION
Instead of using `meta.function` as the selector for function regions in a file, let's instead use `meta.function - meta.function.inline` to filter out any inline functions. This might be better suited to hide behind a preference, but I'm putting it inline for now as an example of what we can do with the selector engine.

This will be useful for keeping stuff like lambda functions in Python out of the list of functions displayed.
