### PR TITLE
Replace selector name 'entity.name.type.class' => 'entity.name.class'

### DIFF
--- a/Function Name Display.sublime-settings
+++ b/Function Name Display.sublime-settings
@@ -1,6 +1,6 @@
 {
 	"display_file": false,
-	"display_class": false,
+	"display_class": true,
 	"display_function": true,
 	"display_arguments": false
 }

--- a/FunctionNameStatus.py
+++ b/FunctionNameStatus.py
@@ -5,37 +5,41 @@ import re
 import sys
 from time import time
 
-# Ideas taken from C0D312, nizur & tito in http://www.sublimetext.com/forum/viewtopic.php?f=2&t=4589
+# Ideas taken from C0D312, nizur & tito in
+# http://www.sublimetext.com/forum/viewtopic.php?f=2&t=4589
 # Also, from https://github.com/SublimeText/WordHighlight/blob/master/word_highlight.py
+
 
 def plugin_loaded():
     global Pref
 
     class Pref:
         def load(self):
-            Pref.display_file      = settings.get('display_file', False)
-            Pref.display_class     = settings.get('display_class', False)
-            Pref.display_function  = settings.get('display_function', True)
+            Pref.display_file = settings.get('display_file', False)
+            Pref.display_class = settings.get('display_class', False)
+            Pref.display_function = settings.get('display_function', True)
             Pref.display_arguments = settings.get('display_arguments', False)
-            Pref.wait_time         = 0.12
-            Pref.time              = time()
+            Pref.wait_time = 0.12
+            Pref.time = time()
 
     settings = sublime.load_settings('Function Name Display.sublime-settings')
     Pref = Pref()
     Pref.load()
-    settings.add_on_change('reload', lambda:Pref.load())
+    settings.add_on_change('reload', lambda: Pref.load())
 
 if sys.version_info[0] == 2:
     plugin_loaded()
 
-clean_name = re.compile('^\s*(public\s+|private\s+|protected\s+|static\s+|function\s+|def\s+)+', re.I)
+clean_name = re.compile('^\s*(public\s+|private\s+|protected\s+|static\s+|function\s+|def\s+)+',
+    re.I)
+
 
 class FunctionNameStatusEventHandler(sublime_plugin.EventListener):
     # on_activated_async seems to not fire on startup
     def on_activated(self, view):
         Pref.time = time()
         view.settings().set('function_name_status_row', -1)
-        sublime.set_timeout(lambda:self.display_current_class_and_function(view, 'activated'), 0)
+        sublime.set_timeout(lambda: self.display_current_class_and_function(view, 'activated'), 0)
 
     # why is it here?
     def on_modified(self, view):
@@ -45,9 +49,11 @@ class FunctionNameStatusEventHandler(sublime_plugin.EventListener):
     def on_selection_modified(self, view):
         now = time()
         if now - Pref.time > Pref.wait_time:
-            sublime.set_timeout(lambda:self.display_current_class_and_function(view, 'selection_modified'), 0)
+            sublime.set_timeout(lambda: self.display_current_class_and_function(view,
+                'selection_modified'), 0)
         else:
-            sublime.set_timeout(lambda:self.display_current_class_and_function_delayed(view), int(1000*Pref.wait_time))
+            sublime.set_timeout(lambda: self.display_current_class_and_function_delayed(view),
+                int(1000 * Pref.wait_time))
         Pref.time = now
 
     def display_current_class_and_function_delayed(self, view):
@@ -55,9 +61,7 @@ class FunctionNameStatusEventHandler(sublime_plugin.EventListener):
         if (now - Pref.time >= Pref.wait_time):
             self.display_current_class_and_function(view, 'selection_modified:delayed')
 
-    # display the current class and function name
-    def display_current_class_and_function(self, view, where):
-        # print("display_current_class_and_function running from " + where)
+    def display_current_class_and_function(self, view, where):  # NOQA
         view_settings = view.settings()
         if view_settings.get('is_widget'):
             return
@@ -74,8 +78,8 @@ class FunctionNameStatusEventHandler(sublime_plugin.EventListener):
             found = False
 
             fname = view.file_name()
-            if Pref.display_file and None != fname:
-                 s = fname + " "
+            if Pref.display_file and fname is not None:
+                s = fname + " "
 
             # Look for any classes
             if Pref.display_class:
@@ -85,7 +89,7 @@ class FunctionNameStatusEventHandler(sublime_plugin.EventListener):
                     if row <= region_row:
                         s += view.substr(r)
                         found = True
-                        break;
+                        break
 
             # Look for any functions
             if Pref.display_function:
@@ -102,7 +106,7 @@ class FunctionNameStatusEventHandler(sublime_plugin.EventListener):
                                 s += name.strip()
                             else:
                                 if 'C++' in view.settings().get('syntax'):
-                                    if Pref.display_class or len(name.split('(')[0].split('::'))<2:
+                                    if Pref.display_class or len(name.split('(')[0].split('::')) < 2:  # NOQA
                                         s += name.split('(')[0].strip()
                                     else:
                                         s += name.split('(')[0].split('::')[1].strip()
@@ -114,7 +118,7 @@ class FunctionNameStatusEventHandler(sublime_plugin.EventListener):
             if not found:
                 view.erase_status('function')
                 fname = view.file_name()
-                if Pref.display_file and None != fname:
+                if Pref.display_file and fname is not None:
                     view.set_status('function', fname)
             else:
                 view.set_status('function', s)

--- a/FunctionNameStatus.py
+++ b/FunctionNameStatus.py
@@ -19,7 +19,7 @@ def plugin_loaded():
             Pref.display_arguments = settings.get('display_arguments', False)
             Pref.wait_time         = 0.12
             Pref.time              = time()
-    
+
     settings = sublime.load_settings('Function Name Display.sublime-settings')
     Pref = Pref()
     Pref.load()
@@ -79,7 +79,7 @@ class FunctionNameStatusEventHandler(sublime_plugin.EventListener):
 
             # Look for any classes
             if Pref.display_class:
-                class_regions = view.find_by_selector('entity.name.type.class')
+                class_regions = view.find_by_selector('entity.name.class')
                 for r in reversed(class_regions):
                     row, col = view.rowcol(r.begin())
                     if row <= region_row:

--- a/README.md
+++ b/README.md
@@ -4,20 +4,7 @@ This plugin displays the current file, class and function name on the status bar
 
 ## Installation
 
-The recommended method of installation is via [Package Control](https://sublime.wbond.net). It will download upgrades to your packages automatically.
+### Linux
 
-### Package Control
-
-* Follow instructions on [https://sublime.wbond.net](https://sublime.wbond.net)
-* Install using Package Control: Install > Function Name Display package
-
-### Using Git
-
-Go to your Sublime Text Packages directory and clone the repository using the command below:
-
-git clone https://github.com/akrabat/SublimeFunctionNameDisplay "Function Name Display"
-
-
-## Limitations
-
-This plugin looks for Sublime's 'entity.name.type.class' and 'entity.name.function' scopes to work out where a class and function starts. Note that it doesn't determine where the class/function ends. 
+cd ~/.config/sublime-text-3/Packages/
+git clone https://github.com/Kraymer/SublimeFunctionNameDisplay.git

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ This plugin displays the current file, class and function name on the status bar
 
 ### Linux
 
-cd ~/.config/sublime-text-3/Packages/
-git clone https://github.com/Kraymer/SublimeFunctionNameDisplay.git
+    cd ~/.config/sublime-text-3/Packages/
+    git clone https://github.com/Kraymer/SublimeFunctionNameDisplay.git

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This plugin displays the current file, class and function name on the status bar in Sublime Text 2 and 3.
 
+## Why The Fork?
+
+At the time of the fork, class name display did not work for .py files in ST3. It fixes that.
+
 ## Installation
 
 ### Linux


### PR DESCRIPTION
This change is required on my ST3 (`Build 3126`) for the plugin to correctly prepend classname.